### PR TITLE
Generalize to PostCSS plugins and add support for brotli compression.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,11 @@ matrix:
     - node_js: '6'
     - node_js: '5'
     - node_js: '4'
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ sudo: false
 language: node_js
 matrix:
   include:
+    - node_js: '7'
+    - node_js: '6'
     - node_js: '5'
     - node_js: '4'
-    - node_js: '0.12'
-      env: NO_ESLINT=true
-
-script: "[[ $NO_ESLINT == true ]] && npm run test-012 || npm test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 sudo: false
 
 language: node_js
-matrix:
-  include:
-    - node_js: '7'
-    - node_js: '6'
-    - node_js: '5'
-    - node_js: '4'
+node_js:
+  - "7"
+  - "6"
+  - "5"
+  - "4"
 env:
   - CXX=g++-4.8
 addons:

--- a/README.md
+++ b/README.md
@@ -24,16 +24,19 @@ npm install css-size --save
 ## Example
 
 ```js
+var postcss = require('postcss');
+var autoprefixer = require('autoprefixer');
 var nano = require('cssnano');
 var css = 'h1 {\n  color: black;\n}\n';
 var nanoOpts = {};
+var cssSize = require("css-size");
 
-function processWithNano(css, options) {
-  return nano.process(css, options);
+function process(css, options) {
+  return postcss([ autoprefixer, nano(options) ]).process(css);
 }
 
 
-cssSize(processWithNano, css, nanoOpts).then(function (results) {
+cssSize(css, nanoOpts, process).then(function (results) {
     console.log(results);
 
 /*
@@ -56,7 +59,7 @@ cssSize(processWithNano, css, nanoOpts).then(function (results) {
 
 });
 
-cssSize.table(processWithNano, css, nanoOpts).then(function (table) {
+cssSize.table(css, nanoOpts, process).then(function (table) {
     console.log(table);
 
 /*

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # css-size [![Build Status](https://travis-ci.org/ben-eb/css-size.svg?branch=master)][ci] [![NPM version](https://badge.fury.io/js/css-size.svg)][npm] [![Dependency Status](https://gemnasium.com/ben-eb/css-size.svg)][deps]
 
-> Display the size of a CSS file.
+> Compare the size of a CSS file after processing it to the original.
 
-All results are shown using the [`gzip-size`] module, as this most accurately
-represents what will be served to a client in production. It also provides a
-better comparison between the minified and the original CSS.
+Results are shown for uncompressed as well as when compressed using gzip
+and brotli. For most users, one of the compressed sizes will best
+represent what will be served to a client in production. It also
+provides a better comparison between the minified and the original CSS.
 
-CSS is minified with [`cssnano`].
+CSS is expected to processed by [`postcss`] plugins.
 
 
 ## Install
@@ -21,35 +22,53 @@ npm install css-size --save
 ## Example
 
 ```js
+var nano = require('cssnano');
 var css = 'h1 {\n  color: black;\n}\n';
+var nanoOpts = {};
 
-cssSize(css).then(function (results) {
+function processWithNano(css, options) {
+  return nano.process(css, options);
+}
+
+
+cssSize(processWithNano, css, nanoOpts).then(function (results) {
     console.log(results);
 
 /*
-    {
-        original: '43 B',
-        minified: '34 B',
-        difference: '9 B',
-        percent: '79.07%'
-    }
+  { uncompressed:
+     { original: '23 B',
+       processed: '14 B',
+       difference: '9 B',
+       percent: '60.87%' },
+    gzip:
+     { original: '43 B',
+       processed: '34 B',
+       difference: '9 B',
+       percent: '79.07%' },
+    brotli:
+     { original: '27 B',
+       processed: '16 B',
+       difference: '11 B',
+       percent: '59.26%' } }
 */
 
 });
 
-cssSize.table(css).then(function (table) {
+cssSize.table(processWithNano, css, nanoOpts).then(function (table) {
     console.log(table);
 
 /*
-    ┌─────────────────┬────────┐
-    │ Original (gzip) │ 43 B   │
-    ├─────────────────┼────────┤
-    │ Minified (gzip) │ 34 B   │
-    ├─────────────────┼────────┤
-    │ Difference      │ 9 B    │
-    ├─────────────────┼────────┤
-    │ Percent         │ 79.07% │
-    └─────────────────┴────────┘
+    ┌────────────┬──────────────┬────────┬────────┐
+    │            │ Uncompressed │ Gzip   │ Brotli │
+    ├────────────┼──────────────┼────────┼────────┤
+    │ Original   │ 23 B         │ 43 B   │ 27 B   │
+    ├────────────┼──────────────┼────────┼────────┤
+    │ Processed  │ 14 B         │ 34 B   │ 16 B   │
+    ├────────────┼──────────────┼────────┼────────┤
+    │ Difference │ 9 B          │ 9 B    │ 11 B   │
+    ├────────────┼──────────────┼────────┼────────┤
+    │ Percent    │ 60.87%       │ 79.07% │ 59.26% │
+    └────────────┴──────────────┴────────┴────────┘
 */
 
 });
@@ -58,14 +77,14 @@ cssSize.table(css).then(function (table) {
 
 ## API
 
-### `cssSize(input, options)`
+### `cssSize(cssProcessor, input, options)`
 
 Pass a string of CSS to receive an object with information about the original &
-minified sizes (both are gzipped), plus difference and percentage results. The
-options object is passed through to cssnano should you wish to compare sizes
+minified sizes (uncompressed, gzipped, and brotli'd), plus difference and percentage results. The
+options object is passed through to the processor should you wish to compare sizes
 using different options than the defaults.
 
-### `cssSize.table(input, options)`
+### `cssSize.table(cssProcessor, input, options)`
 
 Use the table method instead to receive the results as a formatted table.
 
@@ -85,6 +104,8 @@ $ css-size --help
 ## Related
 
 * [`js-size`]: Display the size of a JS file.
+* [`gzip-size`]: Calculate the size of a string after compression with gzip.
+* [`brotli-size`]: Calculate the size of a string after compression with brotli.
 
 
 ## Contributing
@@ -103,5 +124,7 @@ MIT © [Ben Briggs](http://beneb.info)
 [npm]:         http://badge.fury.io/js/css-size
 
 [`cssnano`]:   https://github.com/ben-eb/cssnano
+[`postcss`]:   https://github.com/postcss/postcss
 [`js-size`]:   https://github.com/lukekarrys/js-size
 [`gzip-size`]: https://github.com/sindresorhus/gzip-size
+[`brotli-size`]: https://github.com/erwinmombay/brotli-size

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ and brotli. For most users, one of the compressed sizes will best
 represent what will be served to a client in production. It also
 provides a better comparison between the minified and the original CSS.
 
-CSS is expected to processed by [`postcss`] plugins.
+CSS is expected to processed by [`postcss`] plugins but can be used with
+any processing code that returns a promise that resolves to an object
+with a `css` property.
 
 
 ## Install
@@ -79,7 +81,7 @@ cssSize.table(processWithNano, css, nanoOpts).then(function (table) {
 
 ### `cssSize(cssProcessor, input, options)`
 
-Pass a string of CSS to receive an object with information about the original &
+Pass a string (or Buffer) of CSS to receive an object with information about the original &
 minified sizes (uncompressed, gzipped, and brotli'd), plus difference and percentage results. The
 options object is passed through to the processor should you wish to compare sizes
 using different options than the defaults.

--- a/README.md
+++ b/README.md
@@ -82,20 +82,34 @@ cssSize.table(css, nanoOpts, process).then(function (table) {
 
 ## API
 
-### `cssSize(cssProcessor, input, options)`
+### `cssSize(input, options, processor)`
 
-Pass a string (or Buffer) of CSS to receive an object with information about the original &
-minified sizes (uncompressed, gzipped, and brotli'd), plus difference and percentage results. The
-options object is passed through to the processor should you wish to compare sizes
-using different options than the defaults.
+Pass `input` of CSS to receive an object with information about the
+original & minified sizes (uncompressed, gzipped, and brotli'd), plus
+difference and percentage results. The `options` object is passed
+through to the `processor` should you wish to compare sizes using
+different options than the defaults.
 
-### `cssSize.table(cssProcessor, input, options)`
+### `cssSize.table(input, options, processor)`
 
 Use the table method instead to receive the results as a formatted table.
 
 #### input
 
 Type: `string`, `buffer`
+
+#### options
+
+Type: object
+
+#### processor
+
+Type: function
+
+The processor accepts as arguments the input and options and returns a
+Promise that resolves to an object with a `css` property containing the
+processed css output.
+
 
 ### CLI
 

--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+var cssSize = require("./dist/index.js");
+module.exports = cssSize.default;
+module.exports.table = cssSize.table;

--- a/package.json
+++ b/package.json
@@ -6,11 +6,13 @@
   "bin": {
     "css-size": "dist/cli.js"
   },
+  "engines": {
+    "node": ">=4"
+  },
   "scripts": {
     "pretest": "eslint src",
     "prepublish": "del-cli dist && BABEL_ENV=publish babel src --out-dir dist --ignore /__tests__/",
     "test": "npm run prepublish && ava src/__tests__",
-    "test-012": "npm run prepublish && ava src/__tests__"
   },
   "files": [
     "LICENSE-MIT",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "babel-preset-es2015-loose": "^7.0.0",
     "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.9.0",
-    "cssnano": "^3.3.2",
     "del-cli": "^0.2.0",
     "eslint": "^3.0.0",
     "eslint-config-cssnano": "^3.0.0",
@@ -51,6 +50,7 @@
   "dependencies": {
     "brotli-size": "0.0.1",
     "cli-table": "^0.3.1",
+    "cssnano": "^3.3.2",
     "gzip-size": "^3.0.0",
     "minimist": "^1.2.0",
     "pretty-bytes": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "css-size",
   "version": "1.1.0",
   "description": "Compare the compressed and uncompressed sizes of a CSS file before and after processing.",
-  "main": "dist/index.js",
+  "main": "index.js",
   "bin": {
     "css-size": "dist/cli.js"
   },
@@ -16,6 +16,7 @@
   },
   "files": [
     "LICENSE-MIT",
+    "index.js",
     "dist",
     "usage.txt"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "css-size",
-  "version": "2.0.0",
+  "version": "1.1.0",
   "description": "Compare the compressed and uncompressed sizes of a CSS file before and after processing.",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "pretest": "eslint src",
     "prepublish": "del-cli dist && BABEL_ENV=publish babel src --out-dir dist --ignore /__tests__/",
-    "test": "npm run prepublish && ava src/__tests__",
+    "test": "npm run prepublish && ava src/__tests__"
   },
   "files": [
     "LICENSE-MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "css-size",
-  "version": "1.1.0",
-  "description": "Display the size of a CSS file.",
+  "version": "2.0.0",
+  "description": "Compare the compressed and uncompressed sizes of a CSS file before and after processing.",
   "main": "dist/index.js",
   "bin": {
     "css-size": "dist/cli.js"
@@ -21,6 +21,7 @@
     "bytes",
     "css",
     "gzip",
+    "brotli",
     "size"
   ],
   "license": "MIT",
@@ -33,6 +34,7 @@
     "babel-preset-es2015-loose": "^7.0.0",
     "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.9.0",
+    "cssnano": "^3.3.2",
     "del-cli": "^0.2.0",
     "eslint": "^3.0.0",
     "eslint-config-cssnano": "^3.0.0",
@@ -47,8 +49,8 @@
   },
   "repository": "ben-eb/css-size",
   "dependencies": {
+    "brotli-size": "0.0.1",
     "cli-table": "^0.3.1",
-    "cssnano": "^3.3.2",
     "gzip-size": "^3.0.0",
     "minimist": "^1.2.0",
     "pretty-bytes": "^3.0.0",

--- a/processors/nano.js
+++ b/processors/nano.js
@@ -1,0 +1,5 @@
+var nano = require("cssnano");
+
+module.exports = function(css, opts) {
+  return nano.process(css, opts);
+}

--- a/processors/noop.js
+++ b/processors/noop.js
@@ -1,0 +1,5 @@
+var postcss = require('postcss');
+
+module.exports = function(css, opts) {
+  return postcss([]).process(css, opts);
+}

--- a/processors/noop.js
+++ b/processors/noop.js
@@ -1,5 +1,3 @@
-var postcss = require('postcss');
-
 module.exports = function(css, opts) {
-  return postcss([]).process(css, opts);
+  return Promise.resolve({css: css});
 }

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -5,14 +5,14 @@ import test from 'ava';
 import size from '../';
 import nanoProcessor from '../../processors/nano.js';
 
+let noopProcessorPath = path.resolve(__dirname, '../../processors/noop.js');
+
 function setup (args) {
     return new Promise((resolve, reject) => {
         process.chdir(__dirname);
 
         let ps = spawn(process.execPath, [
             path.resolve(__dirname, '../../dist/cli.js'),
-            '-p',
-            path.resolve(__dirname, '../../processors/nano.js'),
         ].concat(args));
 
         let out = '';
@@ -37,6 +37,14 @@ test('cli', t => {
         t.truthy(~out.indexOf('34 B'));
         t.truthy(~out.indexOf('9 B'));
         t.truthy(~out.indexOf('79.07%'));
+    });
+});
+
+test('cli with processor argument', t => {
+    console.log(noopProcessorPath);
+    return setup(['-p', noopProcessorPath, 'test.css']).then(results => {
+        let out = results[0];
+        t.truthy(~out.indexOf('100%'));
     });
 });
 

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -3,7 +3,6 @@ import {spawn} from 'child_process';
 import path from 'path';
 import test from 'ava';
 import size from '../';
-import nanoProcessor from '../../processors/nano.js';
 
 let noopProcessorPath = path.resolve(__dirname, '../../processors/noop.js');
 
@@ -49,7 +48,7 @@ test('cli with processor argument', t => {
 });
 
 test('api', t => {
-    return size(nanoProcessor, read('test.css', 'utf-8')).then(result => {
+    return size(read('test.css', 'utf-8')).then(result => {
         t.deepEqual(result, {
             uncompressed: {
                 original: '23 B',
@@ -75,7 +74,6 @@ test('api', t => {
 
 test('api options', t => {
     return size(
-        nanoProcessor,
         '@namespace islands url("http://bar.yandex.ru/ui/islands");', {
             discardUnused: false,
         }

--- a/src/cli.js
+++ b/src/cli.js
@@ -3,7 +3,6 @@
 import fs from 'fs';
 import process from 'process';
 import path from 'path';
-import nano from 'cssnano';
 import read from 'read-file-stdin';
 import minimist from 'minimist';
 import {table} from './';
@@ -31,11 +30,11 @@ if (opts.version) {
             if (err) {
                 throw err;
             }
-            let processor = nano.process.bind(nano);
+            let processor = null;
             if (opts.processor) {
                 processor = require(path.resolve(process.cwd(), opts.processor));
             }
-            table(processor, buf, opts.options).then((results) => console.log(results));
+            table(buf, opts.options, processor).then((results) => console.log(results));
         });
     }
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -3,6 +3,7 @@
 import fs from 'fs';
 import process from 'process';
 import path from 'path';
+import nano from 'cssnano';
 import read from 'read-file-stdin';
 import minimist from 'minimist';
 import {table} from './';
@@ -21,7 +22,7 @@ if (opts.version) {
 } else {
     let file = opts._[0];
 
-    if (file === 'help' || opts.help || !opts.processor) {
+    if (file === 'help' || opts.help) {
         fs.createReadStream(__dirname + '/../usage.txt')
             .pipe(process.stdout)
             .on('close', () => process.exit(1));
@@ -30,7 +31,10 @@ if (opts.version) {
             if (err) {
                 throw err;
             }
-            let processor = require(path.resolve(process.cwd(), opts.processor));
+            let processor = nano.process.bind(nano);
+            if (opts.processor) {
+                processor = require(path.resolve(process.cwd(), opts.processor));
+            }
             table(processor, buf, opts.options).then((results) => console.log(results));
         });
     }

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
 import fs from 'fs';
+import process from 'process';
+import path from 'path';
 import read from 'read-file-stdin';
 import minimist from 'minimist';
 import {table} from './';
@@ -9,15 +11,17 @@ const opts = minimist(process.argv.slice(2), {
     alias: {
         h: 'help',
         v: 'version',
+        p: 'processor',
     },
 });
+
 
 if (opts.version) {
     console.log(require('../package.json').version);
 } else {
     let file = opts._[0];
 
-    if (file === 'help' || opts.help) {
+    if (file === 'help' || opts.help || !opts.processor) {
         fs.createReadStream(__dirname + '/../usage.txt')
             .pipe(process.stdout)
             .on('close', () => process.exit(1));
@@ -26,7 +30,8 @@ if (opts.version) {
             if (err) {
                 throw err;
             }
-            table(buf, opts.options).then((results) => console.log(results));
+            let processor = require(path.resolve(process.cwd(), opts.processor));
+            table(processor, buf, opts.options).then((results) => console.log(results));
         });
     }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import {sync as gzip} from 'gzip-size';
 import {sync as brotli} from 'brotli-size';
 import Table from 'cli-table';
 import round from 'round-precision';
+import nano from 'cssnano';
 
 const getBinarySize = (string) => {
     return Buffer.byteLength(string, 'utf8');
@@ -12,9 +13,10 @@ const percentDifference = (original, minified) => {
     return round((minified / original) * 100, 2) + '%';
 };
 
-const cssSize = (cssCallback, css, opts) => {
+const cssSize = (css, opts, processor) => {
+    processor = processor || nano.process.bind(nano);
     css = css.toString();
-    return cssCallback(css, opts).then(result => {
+    return processor(css, opts).then(result => {
         let originalUncompressed = getBinarySize(css);
         let minifiedUncompressed = getBinarySize(result.css);
 
@@ -71,8 +73,8 @@ const tableize = (data) => {
     };
 };
 
-export function table (css, opts) {
-    return cssSize(css, opts).then(data => {
+export function table (css, opts, processor) {
+    return cssSize(css, opts, processor).then(data => {
         let result = tableize(data);
         let output = new Table({head: result.head});
         output.push.apply(output, result.rows);

--- a/src/index.js
+++ b/src/index.js
@@ -1,36 +1,81 @@
-import nano from 'cssnano';
 import prettyBytes from 'pretty-bytes';
 import {sync as gzip} from 'gzip-size';
+import {sync as brotli} from 'brotli-size';
 import Table from 'cli-table';
 import round from 'round-precision';
 
-const cssSize = (css, opts) => {
+const getBinarySize = (string) => {
+    return Buffer.byteLength(string, 'utf8');
+};
+
+const percentDifference = (original, minified) => {
+    return round((minified / original) * 100, 2) + '%';
+};
+
+const cssSize = (cssCallback, css, opts) => {
     css = css.toString();
-    return nano.process(css, opts).then(result => {
-        let original = gzip(css);
-        let minified = gzip(result.css);
+    return cssCallback(css, opts).then(result => {
+        let originalUncompressed = getBinarySize(css);
+        let minifiedUncompressed = getBinarySize(result.css);
+
+        let originalGzip = gzip(css);
+        let minifiedGzip = gzip(result.css);
+
+        let originalBrotli = brotli(css);
+        let minifiedBrotli = brotli(result.css);
 
         return {
-            original: prettyBytes(original),
-            minified: prettyBytes(minified),
-            difference: prettyBytes(original - minified),
-            percent: round((minified / original) * 100, 2) + '%',
+            uncompressed: {
+                original: prettyBytes(originalUncompressed),
+                processed: prettyBytes(minifiedUncompressed),
+                difference: prettyBytes(originalUncompressed - minifiedUncompressed),
+                percent: percentDifference(originalUncompressed, minifiedUncompressed),
+            },
+            gzip: {
+                original: prettyBytes(originalGzip),
+                processed: prettyBytes(minifiedGzip),
+                difference: prettyBytes(originalGzip - minifiedGzip),
+                percent: percentDifference(originalGzip, minifiedGzip),
+            },
+            brotli: {
+                original: prettyBytes(originalBrotli),
+                processed: prettyBytes(minifiedBrotli),
+                difference: prettyBytes(originalBrotli - minifiedBrotli),
+                percent: percentDifference(originalBrotli, minifiedBrotli),
+            },
         };
     });
 };
 
+const tableize = (data) => {
+    return {
+        head: ["", "Uncompressed", "Gzip", "Brotli"],
+        rows: [
+            {Original:   [
+                data.uncompressed.original,
+                data.gzip.original,
+                data.brotli.original ]},
+            {Processed:  [
+                data.uncompressed.processed,
+                data.gzip.processed,
+                data.brotli.processed ]},
+            {Difference: [
+                data.uncompressed.difference,
+                data.gzip.difference,
+                data.brotli.difference ]},
+            {Percent:    [
+                data.uncompressed.percent,
+                data.gzip.percent,
+                data.brotli.percent ]},
+        ],
+    };
+};
+
 export function table (css, opts) {
-    let output = new Table();
-    return cssSize(css, opts).then(result => {
-        output.push.apply(output, Object.keys(result).map((key, i) => {
-            let label = key.slice(0, 1).toUpperCase() + key.slice(1);
-            if (i < 2) {
-                label += ' (gzip)';
-            }
-            let row = {};
-            row[label] = result[key];
-            return row;
-        }));
+    return cssSize(css, opts).then(data => {
+        let result = tableize(data);
+        let output = new Table({head: result.head});
+        output.push.apply(output, result.rows);
         return output.toString();
     });
 };

--- a/usage.txt
+++ b/usage.txt
@@ -7,7 +7,7 @@ Options:
     --processor,  -p    Path to the postcss processor code.
 
     --options           Pass through options to the postcss plugin. For example,
-                        you can turn off unused rule removal
+                        if using cssnano, you can turn off unused rule removal
                         with `--no-options.discardUnused`.
 
     --help,       -h    Outputs this help screen.
@@ -22,5 +22,5 @@ Example:
     var mypostcssplugin = require('mypostcssplugin');
     module.exports = function(css, opts) {
       var plugin = mypostcssplugin(opts);
-      return postcss([plugin]).process(css, opts);
+      return postcss([plugin]).process(css);
     }

--- a/usage.txt
+++ b/usage.txt
@@ -4,8 +4,23 @@ Options:
 
     --version,    -v    Outputs the version number.
 
-    --options           Pass through options to cssnano. For example,
+    --processor,  -p    Path to the postcss processor code.
+
+    --options           Pass through options to the postcss plugin. For example,
                         you can turn off unused rule removal
                         with `--no-options.discardUnused`.
 
     --help,       -h    Outputs this help screen.
+
+
+The processor script should export a function that returns a postcss processor promise given
+a CSS string and the command line options as arguments.
+
+Example:
+
+    var postcss = require('postcss');
+    var mypostcssplugin = require('mypostcssplugin');
+    module.exports = function(css, opts) {
+      var plugin = mypostcssplugin(opts);
+      return postcss([plugin]).process(css, opts);
+    }

--- a/usage.txt
+++ b/usage.txt
@@ -4,7 +4,7 @@ Options:
 
     --version,    -v    Outputs the version number.
 
-    --processor,  -p    Path to the postcss processor code.
+    --processor,  -p    Path to the postcss processor code. If omitted, defaults to cssnano.
 
     --options           Pass through options to the postcss plugin. For example,
                         if using cssnano, you can turn off unused rule removal
@@ -13,8 +13,9 @@ Options:
     --help,       -h    Outputs this help screen.
 
 
-The processor script should export a function that returns a postcss processor promise given
-a CSS string and the command line options as arguments.
+The processor script should export a function that given a CSS string and the
+command line options as arguments returns a Promise that resolves to an object
+with a css property. Note that postcss's process method conforms to this API.
 
 Example:
 


### PR DESCRIPTION
I'm working on some CSS compression tools and this looked like it could be generalized to support arbitrary postcss pipelines so I worked that up. The cli tool now takes a new required option to a small js file that does the actual css processing.

Also, brotli is becoming increasingly common so it now reports on brotli compression in addition to gzip. I also threw in uncompressed sizes for shit and giggles.

I've moved cssnano to a dev dependency. There's some example processors in the processors folder (also used for testing the cli).
