### PR TITLE
Typescript type definition for the public API.

### DIFF
--- a/css-size.d.ts
+++ b/css-size.d.ts
@@ -1,0 +1,42 @@
+export = cssSize;
+
+
+declare function cssSize(
+  css: string,
+  options: cssSize.ProcessOptions,
+  processor?: cssSize.Processor
+): Promise<cssSize.Result>;
+
+declare namespace cssSize {
+  function table(
+    css: string,
+    options: ProcessOptions,
+    processor?: Processor
+  ): Promise<string>;
+  interface HasCss {
+    css: string;
+  }
+  interface ProcessOptions {
+    [opt: string]: any;
+  }
+  type Processor = (css: string, options: ProcessOptions) => Promise<HasCss>;
+
+  /**
+   * The size before and after, the absolute different and the percent improvement.
+   */
+  interface SizeInfo {
+    original: string;
+    processed: string;
+    difference: string;
+    percent: string;
+  }
+
+  /**
+   *  Size deltas of the css in various formats.
+   */
+  interface Result {
+    uncompressed: SizeInfo;
+    gzip: SizeInfo;
+    brotli: SizeInfo;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -65,5 +65,6 @@
   },
   "ava": {
     "require": "babel-register"
-  }
+  },
+  "types": "css-size.d.ts"
 }


### PR DESCRIPTION
I am using typescript with css-size and needed to build a definition file for it. If you want to ship with it, here it is. For most typescript users, this is the best option assuming the API definition is kept in sync with releases. otherwise this can also be published as `@types/css-size` and maintained by the typescript community.