### PR TITLE
Numeric results

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,32 @@ cssSize.table(css, nanoOpts, process).then(function (table) {
 */
 
 });
+
+cssSize.numeric(css, nanoOpts, process).then(function (results) {
+    console.log(results);
+/*
+{
+  uncompressed: {
+    original: 23,
+    processed: 14,
+    difference: 9,
+    percent: 0.6087
+  },
+  gzip: {
+    original: 43,
+    processed: 34,
+    difference: 9,
+    percent: 0.7907
+  },
+  brotli: {
+    original: 27,
+    processed: 16,
+    difference: 11,
+    percent: 0.5926
+  }
+}
+*/
+});
 ```
 
 
@@ -89,6 +115,12 @@ original & minified sizes (uncompressed, gzipped, and brotli'd), plus
 difference and percentage results. The `options` object is passed
 through to the `processor` should you wish to compare sizes using
 different options than the defaults.
+
+### `cssSize.numeric(input, options, processor)`
+
+Exactly like `cssSize(...)` except the results are returned as numbers
+instead of preformatted strings. In numeric mode, the `percentage` value is a
+fraction (rounded to 4 significant digits), instead of being scaled to `100%`.
 
 ### `cssSize.table(input, options, processor)`
 

--- a/css-size.d.ts
+++ b/css-size.d.ts
@@ -5,7 +5,7 @@ declare function cssSize(
   css: string,
   options: cssSize.ProcessOptions,
   processor?: cssSize.Processor
-): Promise<cssSize.Result>;
+): Promise<cssSize.Result<string>>;
 
 declare namespace cssSize {
   function table(
@@ -13,6 +13,13 @@ declare namespace cssSize {
     options: ProcessOptions,
     processor?: Processor
   ): Promise<string>;
+
+  function numeric(
+    css: string,
+    options: ProcessOptions,
+    processor?: Processor
+  ): Promise<Result<number>>;
+
   interface HasCss {
     css: string;
   }
@@ -24,19 +31,19 @@ declare namespace cssSize {
   /**
    * The size before and after, the absolute different and the percent improvement.
    */
-  interface SizeInfo {
-    original: string;
-    processed: string;
-    difference: string;
-    percent: string;
+  interface SizeInfo<T extends string | number> {
+    original: T;
+    processed: T;
+    difference: T;
+    percent: T;
   }
 
   /**
    *  Size deltas of the css in various formats.
    */
-  interface Result {
-    uncompressed: SizeInfo;
-    gzip: SizeInfo;
-    brotli: SizeInfo;
+  interface Result<T extends string | number> {
+    uncompressed: SizeInfo<T>;
+    gzip: SizeInfo<T>;
+    brotli: SizeInfo<T>;
   }
 }

--- a/css-size.d.ts
+++ b/css-size.d.ts
@@ -1,0 +1,42 @@
+export = cssSize;
+
+
+declare function cssSize(
+  css: string,
+  options: cssSize.ProcessOptions,
+  processor?: cssSize.Processor
+): Promise<cssSize.Result>;
+
+declare namespace cssSize {
+  function table(
+    css: string,
+    options: ProcessOptions,
+    processor?: Processor
+  ): Promise<string>;
+  interface HasCss {
+    css: string;
+  }
+  interface ProcessOptions {
+    [opt: string]: any;
+  }
+  type Processor = (css: string, options: ProcessOptions) => Promise<HasCss>;
+
+  /**
+   * The size before and after, the absolute different and the percent improvement.
+   */
+  interface SizeInfo {
+    original: string;
+    processed: string;
+    difference: string;
+    percent: string;
+  }
+
+  /**
+   *  Size deltas of the css in various formats.
+   */
+  interface Result {
+    uncompressed: SizeInfo;
+    gzip: SizeInfo;
+    brotli: SizeInfo;
+  }
+}

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
 var cssSize = require("./dist/index.js");
 module.exports = cssSize.default;
 module.exports.table = cssSize.table;
+module.exports.numeric = cssSize.numeric;

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-preset-es2015-loose": "^7.0.0",
     "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.9.0",
+    "colors": "^1.1.2",
     "del-cli": "^0.2.0",
     "eslint": "^3.0.0",
     "eslint-config-cssnano": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -65,5 +65,6 @@
   },
   "ava": {
     "require": "babel-register"
-  }
+  },
+  "types": "css-size.d.ts"
 }

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -3,7 +3,7 @@ import {spawn} from 'child_process';
 import path from 'path';
 import colors from 'colors/safe';
 import test from 'ava';
-import size, {table} from '../';
+import size, {table, numeric} from '../';
 
 let noopProcessorPath = path.resolve(__dirname, '../../processors/noop.js');
 
@@ -87,6 +87,31 @@ test('table', t => {
 ├────────────┼──────────────┼────────┼────────┤
 │ Percent    │ 60.87%       │ 79.07% │ 59.26% │
 └────────────┴──────────────┴────────┴────────┘`.trim());
+    });
+});
+
+test('numeric', t => {
+    return numeric(read('test.css', 'utf-8')).then(result => {
+        t.deepEqual(result, {
+            uncompressed: {
+                original: 23,
+                processed: 14,
+                difference: 9,
+                percent: 0.6087,
+            },
+            gzip: {
+                original: 43,
+                processed: 34,
+                difference: 9,
+                percent: 0.7907,
+            },
+            brotli: {
+                original: 27,
+                processed: 16,
+                difference: 11,
+                percent: 0.5926,
+            },
+        });
     });
 });
 

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1,8 +1,9 @@
 import {readFileSync as read} from 'fs';
 import {spawn} from 'child_process';
 import path from 'path';
+import colors from 'colors/safe';
 import test from 'ava';
-import size from '../';
+import size, {table} from '../';
 
 let noopProcessorPath = path.resolve(__dirname, '../../processors/noop.js');
 
@@ -69,6 +70,23 @@ test('api', t => {
                 percent: '59.26%',
             },
         });
+    });
+});
+
+test('table', t => {
+    return table(read('test.css', 'utf-8')).then(result => {
+        t.deepEqual(colors.stripColors(result), `
+┌────────────┬──────────────┬────────┬────────┐
+│            │ Uncompressed │ Gzip   │ Brotli │
+├────────────┼──────────────┼────────┼────────┤
+│ Original   │ 23 B         │ 43 B   │ 27 B   │
+├────────────┼──────────────┼────────┼────────┤
+│ Processed  │ 14 B         │ 34 B   │ 16 B   │
+├────────────┼──────────────┼────────┼────────┤
+│ Difference │ 9 B          │ 9 B    │ 11 B   │
+├────────────┼──────────────┼────────┼────────┤
+│ Percent    │ 60.87%       │ 79.07% │ 59.26% │
+└────────────┴──────────────┴────────┴────────┘`.trim());
     });
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -17,36 +17,36 @@ const cssSize = (css, opts, processor) => {
     processor = processor || nano.process.bind(nano);
     css = css.toString();
     return processor(css, opts).then(result => {
-        let originalUncompressed = getBinarySize(css);
-        let minifiedUncompressed = getBinarySize(result.css);
-
-        let originalGzip = gzip(css);
-        let minifiedGzip = gzip(result.css);
-
-        let originalBrotli = brotli(css);
-        let minifiedBrotli = brotli(result.css);
-
-        return {
-            uncompressed: {
-                original: prettyBytes(originalUncompressed),
-                processed: prettyBytes(minifiedUncompressed),
-                difference: prettyBytes(originalUncompressed - minifiedUncompressed),
-                percent: percentDifference(originalUncompressed, minifiedUncompressed),
-            },
-            gzip: {
-                original: prettyBytes(originalGzip),
-                processed: prettyBytes(minifiedGzip),
-                difference: prettyBytes(originalGzip - minifiedGzip),
-                percent: percentDifference(originalGzip, minifiedGzip),
-            },
-            brotli: {
-                original: prettyBytes(originalBrotli),
-                processed: prettyBytes(minifiedBrotli),
-                difference: prettyBytes(originalBrotli - minifiedBrotli),
-                percent: percentDifference(originalBrotli, minifiedBrotli),
-            },
-        };
+        let sizes = computeSizes(css, result.css);
+        deltasAsStrings(sizes.uncompressed);
+        deltasAsStrings(sizes.gzip);
+        deltasAsStrings(sizes.brotli);
+        return sizes;
     });
+};
+
+const deltasAsStrings = (sizes) => {
+    sizes.difference = prettyBytes(sizes.original - sizes.processed);
+    sizes.percent = percentDifference(sizes.original, sizes.processed);
+    sizes.original = prettyBytes(sizes.original);
+    sizes.processed = prettyBytes(sizes.processed);
+};
+
+const computeSizes = (original, minified) => {
+    return {
+        uncompressed: {
+            original: getBinarySize(original),
+            processed: getBinarySize(minified),
+        },
+        gzip: {
+            original: gzip(original),
+            processed: gzip(minified),
+        },
+        brotli: {
+            original: brotli(original),
+            processed: brotli(minified),
+        },
+    };
 };
 
 const tableize = (data) => {
@@ -80,6 +80,23 @@ export function table (css, opts, processor) {
         output.push.apply(output, result.rows);
         return output.toString();
     });
+};
+
+export function numeric (css, opts, processor) {
+    processor = processor || nano.process.bind(nano);
+    css = css.toString();
+    return processor(css, opts).then(result => {
+        let sizes = computeSizes(css, result.css);
+        deltasAsNumbers(sizes.uncompressed);
+        deltasAsNumbers(sizes.gzip);
+        deltasAsNumbers(sizes.brotli);
+        return sizes;
+    });
+}
+
+const deltasAsNumbers = (sizes) => {
+    sizes.difference = sizes.original - sizes.processed;
+    sizes.percent = round(sizes.processed / sizes.original, 4);
 };
 
 export default cssSize;


### PR DESCRIPTION
I need to be able to write tests against css size calculations so I added a numeric mode.

note: this includes the typescript defintions from https://github.com/ben-eb/css-size/pull/32